### PR TITLE
Rewrite Dockerfile not to rely on local build artifacts presence

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,15 +10,8 @@
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
-# External packages folder
-vendor
-_vendor-*/
-
 # Dot env files
 .env
-
-# Git folder
-.git
 
 # Build and release artifacts
 .build
@@ -27,3 +20,6 @@ faktory_exporter
 *.tar.gz
 *.mprof
 *-stamp
+
+# To prevent Docker layer cache misses in Dockerfile-only changes
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,21 @@
+FROM golang:1.11 AS builder
+
+RUN go get -u github.com/golang/dep/cmd/dep
+
+RUN mkdir -p $GOPATH/src/github.com/lukasmalkmus/faktory_exporter/
+
+COPY . $GOPATH/src/github.com/lukasmalkmus/faktory_exporter/
+
+WORKDIR $GOPATH/src/github.com/lukasmalkmus/faktory_exporter/
+
+RUN dep ensure
+
+RUN make PREFIX=/bin
+
 FROM  quay.io/prometheus/busybox:latest
 LABEL maintainer "Lukas Malkmus <mail@lukasmalkmus.com>"
 
-COPY faktory_exporter /bin/faktory_exporter
+COPY --from=builder /bin/faktory_exporter /bin/faktory_exporter
 
 EXPOSE      9386
 ENTRYPOINT  ["/bin/faktory_exporter"]


### PR DESCRIPTION
So Docker image can be built with only the source code.

Also it allows to set up automated CI builds, like this: https://hub.docker.com/repository/docker/envek/faktory_exporter/builds